### PR TITLE
chore: pin npm 11 and add min-release-age supply-chain gate

### DIFF
--- a/.github/workflows/npm-audit-signatures.yml
+++ b/.github/workflows/npm-audit-signatures.yml
@@ -1,0 +1,31 @@
+name: NPM Audit Signatures
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "package.json"
+      - "package-lock.json"
+  pull_request:
+    paths:
+      - "package.json"
+      - "package-lock.json"
+
+permissions:
+  contents: read
+
+jobs:
+  audit-signatures:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Install npm 11.12.1 (npm 10 ignores min-release-age)
+        run: npm install -g npm@11.12.1
+
+      - run: npm ci --ignore-scripts
+      - run: npm audit signatures --min-release-age=0

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+; npm 11+ required: npm 10 silently ignores min-release-age
+min-release-age=3

--- a/package-lock.json
+++ b/package-lock.json
@@ -64,7 +64,8 @@
         "vite-plus": "^0.2.6"
       },
       "engines": {
-        "node": ">=22"
+        "node": ">=22",
+        "npm": ">=11 <12"
       }
     },
     "node_modules/@asamuzakjp/css-color": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "version": "1.0.0",
   "description": "Nick Taylor's personal website built with Astro",
   "engines": {
-    "node": ">=22"
+    "node": ">=22",
+    "npm": ">=11 <12"
   },
   "scripts": {
     "dev": "portless run astro dev",


### PR DESCRIPTION
Closes #1031

## What

- Add `.npmrc` with `min-release-age=3` — a 3-day quarantine window before a newly-published dependency version can be installed. Guards against just-published malicious versions (e.g. the axios-style supply-chain attack pattern); npm 10 silently ignores this setting, so npm 11 is required for it to actually do anything.
- Add `"npm": ">=11 <12"` to `engines`, alongside the existing `packageManager: "npm@11.12.1"` pin, to make the requirement explicit.
- Add `.github/workflows/npm-audit-signatures.yml`: installs npm 11.12.1 explicitly (Node's bundled npm won't match the pin) and runs `npm audit signatures --min-release-age=0` whenever `package.json`/`package-lock.json` change, verifying registry signatures and provenance attestations.

## Why now, why not a bug fix

I checked whether Node's bundled npm (10.9.4 for Node 22) causes any actual `npm ci` lockfile problem here — it doesn't; `npm ci` succeeds cleanly with npm 10.9.4 on this repo's dependency tree. So this is a proactive hardening change, not a fix for a broken build.

## Verification

Ran locally with npm 11.12.1:
- `npm ci` — succeeds
- `npm ci --ignore-scripts` — succeeds
- `npm audit signatures --min-release-age=0` — 1254 packages verified registry signatures, 284 verified attestations, no failures

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Added automated npm signature audits to verify package integrity.
  * Configured dependency installation to allow packages only after a three-day release age.

* **Chores**
  * Standardized supported tooling to Node.js 22 and npm 11.x.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->